### PR TITLE
Changing \areaname according to the document language

### DIFF
--- a/capa-epusp-abntex2.sty
+++ b/capa-epusp-abntex2.sty
@@ -39,7 +39,13 @@
 % ---
 
 % Comandos de dados - Area de Concentracao
-\newcommand{\areaname}{Área de Concentração:}
+\newcommand{\areaname}{%
+  \iflanguage{brazil}{Área de Concentração:}{%
+    \iflanguage{spanish}{Área de Concentración:}{%
+      \iflanguage{english}{Area of Concentration:}{Area of Concentration:}
+    }%
+  }%
+}%
 
 \providecommand{\imprimirAreaConcentracaoRotulo}{}
 \providecommand{\imprimirAreaConcentracao}{}


### PR DESCRIPTION
When using the document in another language (e.g. English, Spanish), the \areaname variable is translated